### PR TITLE
Update for 20.05.00

### DIFF
--- a/Koha/Plugin/Com/BibLibre/DIBSPayments/callback.pl
+++ b/Koha/Plugin/Com/BibLibre/DIBSPayments/callback.pl
@@ -59,6 +59,10 @@ if ($statuscode and $statuscode == 2) {
         }
     ); 
 
+    if (ref $accountline_id eq 'HASH') {
+        $accountline_id = $accountline_id->{payment_id};
+    }
+
     # Link payment to dibs_transactions
     my $dbh   = C4::Context->dbh;
     my $sth   = $dbh->prepare(


### PR DESCRIPTION
Chec if returned paymentid is a hashref, to account for Koha bug 23051.